### PR TITLE
suppressing name screen at back gesture

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
@@ -11,7 +11,7 @@
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2025-01-11T10:17:31.272924Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2025-01-30T14:41:26.219460Z" />
   </component>
 </project>

--- a/app/src/main/java/com/shoutboxapp/shoutbox/MainActivity.kt
+++ b/app/src/main/java/com/shoutboxapp/shoutbox/MainActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Observer
 import androidx.navigation.NavType
@@ -82,17 +84,29 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     val navController = rememberNavController()
-
-                    NavHost(navController, startDestination = if (nameExists == true) "chat/${nameOfUser}" else "name"){
-                        composable("name"){
-                            NameScreen(navController = navController, viewModel = nameViewModel)
-                        }
-                        composable("chat/{dataKey}",
-                            arguments = listOf(navArgument("dataKey"){type = NavType.StringType})
-                        ){ backStackEntry ->
-                            ChatAppScreen(navController = navController,
-                                viewModel = shoutsViewModel,
-                                nameOfUser)
+                    if (nameExists == true) {
+                        ChatAppScreen(
+                            navController = navController,
+                            viewModel = shoutsViewModel,
+                            nameOfUser
+                        )
+                    }else {
+                        NavHost(navController, startDestination = if (nameExists == true) "chat/${nameOfUser}" else "name") {
+                            composable("name") {
+                                NameScreen(navController = navController, viewModel = nameViewModel)
+                            }
+                            composable(
+                                "chat/{dataKey}",
+                                arguments = listOf(navArgument("dataKey") {
+                                    type = NavType.StringType
+                                })
+                            ) { backStackEntry ->
+                                ChatAppScreen(
+                                    navController = navController,
+                                    viewModel = shoutsViewModel,
+                                    nameOfUser
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/shoutboxapp/shoutbox/screens/NameScreen.kt
+++ b/app/src/main/java/com/shoutboxapp/shoutbox/screens/NameScreen.kt
@@ -91,7 +91,9 @@ fun NameScreen(navController: NavController,
         Button(
             onClick = {
                 viewModel.setName("$nameOfShouter")
-                navController.navigate("chat/$nameOfShouter")
+                navController.navigate("chat/$nameOfShouter"){
+                    popUpTo("screen1") { inclusive = true }
+                }
             },
             enabled = isButtonEnabled.value,
             modifier = Modifier


### PR DESCRIPTION
Problem: currently if someone make gesture of navigating back from chatscreen, it just lands on starting name screen.
if name exist and user is at namescreen, he shouldn't be allowed to go back.

Fix: There is need for selecting UI draw based on whether name exist or not.
If name exist, then only Chatscreen needs to be drawn,
else if name doesn't exist then whole navigation sequence from name screen to chat screen needs to be loaded.